### PR TITLE
Fixed Disqus comments

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,8 @@ baseurl: "/end2end"
 # google_analytics: UA-52446115-1
 repo: http://github.com/nandomoreirame/end2end
 disqus_shortname: "fernandomoreira"
+disqus_site_shortname: "fernandomoreira"
+
 
 # Author settings
 author:

--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,6 @@ repo: http://github.com/nandomoreirame/end2end
 disqus_shortname: "fernandomoreira"
 disqus_site_shortname: "fernandomoreira"
 
-
 # Author settings
 author:
   name      : Fernando Moreira

--- a/source/_includes/comments.html
+++ b/source/_includes/comments.html
@@ -1,30 +1,26 @@
 {% if page.comments %}
-  <hr>
+<hr>
 
-  <aside id="comments" class="disqus">
+<aside id="comments" class="disqus">
 
-    <div class="container">
-      <h3><i class="icon icon-comments-o"></i> Comments</h3>
-      <div id="disqus_thread"></div>
+  <div class="container">
+    <h3><i class="icon icon-comments-o"></i> Comments</h3>
+    <div id="disqus_thread"></div>
+    <script>
+      var disqus_config = function() {
+        this.page.url = '{{ site.url }}{{ post.url }}';
+        this.page.identifier = '{{ page.id }}';
+      };
+      (function() {
+        var d = document,
+          s = d.createElement('script');
+        s.src = '//{{ site.disqus_site_shortname }}.disqus.com/embed.js';
+        s.setAttribute('data-timestamp', +new Date());
+        (d.head || d.body).appendChild(s);
+      })();
+    </script>
+    <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>
+  </div>
 
-      <script type="text/javascript">
-        var disqus_shortname = '{{ site.disqus_shortname }}';
-        var disqus_identifier = '{{ page.id }}';
-        var disqus_title = '{{ page.title }}';
-        var disqus_url = '{{ site.url }}{{ post.url }}';
-        /*var disqus_developer = 1;*/
-
-        (function() {
-            var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-            dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
-            (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-
-      <noscript>
-        Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a>
-      </noscript>
-    </div>
-
-  </aside>
+</aside>
 {% endif %}

--- a/source/_includes/comments.html
+++ b/source/_includes/comments.html
@@ -2,7 +2,6 @@
 <hr>
 
 <aside id="comments" class="disqus">
-
   <div class="container">
     <h3><i class="icon icon-comments-o"></i> Comments</h3>
     <div id="disqus_thread"></div>
@@ -13,7 +12,7 @@
       };
       (function() {
         var d = document,
-          s = d.createElement('script');
+        s = d.createElement('script');
         s.src = '//{{ site.disqus_site_shortname }}.disqus.com/embed.js';
         s.setAttribute('data-timestamp', +new Date());
         (d.head || d.body).appendChild(s);
@@ -21,6 +20,5 @@
     </script>
     <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>
   </div>
-
 </aside>
 {% endif %}


### PR DESCRIPTION
Not sure when but at some point disqus has changed there universal comment code since you implemented comments. it's no longer 

``` javascript
(function() {
            var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
            dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
            (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body' [0]).appendChild(dsq);
})();
```

It has since been changed to 

``` javascript
var disqus_config = function () {
      this.page.url = '{{ site.url }}{{ post.url }}';
      this.page.identifier = '{{ page.id }}';
      };
      (function() {
        var d = document,
        s = d.createElement('script');
        s.src = '//yoursiteshortname.disqus.com/embed.js';
        s.setAttribute('data-timestamp', +new Date());
        (d.head || d.body).appendChild(s);
      })();
```

Which means it did not work. I have added a disqus_site_shortname attribute inside the _config.yml so it can be supported. This was a roadblock I ran into when using this template and I hope this helps anyone else who goes to use this.

Also. . .

Thanks so much for the absolute amazing template! I've been building small web apps for almost six months now and it came to the point where my content needed a home. Thank you so much for providing a starting ground for that home :)
