### PR TITLE
bottom margin for home's link boxes

### DIFF
--- a/source/_scss/_layout.scss
+++ b/source/_scss/_layout.scss
@@ -171,6 +171,7 @@ body {
     background-color: transparent;
     border: 2px solid $primary-color;
     color: $primary-color;
+    margin-bottom: 2px;
   }
 
   &.disabled,


### PR DESCRIPTION
Problem:
Link boxes to pages from the home site overlay on mobile view (tested on iOS Safari) when split into rows.

Solution:
Add bottom margin.
