### PR TITLE
post page comment box not included issue

### DIFF
--- a/source/_includes/comments.html
+++ b/source/_includes/comments.html
@@ -1,4 +1,4 @@
-{% if page.comments %}
+{% if site.comments %}
 <hr>
 
 <aside id="comments" class="disqus">


### PR DESCRIPTION
#18

_include/comments.html is not included in post.html.

It works well if I modify the condition at _include/comments.html line 1

{% if page.comments %}
to
{% if site.comments %}
