### PR TITLE
Added json dependency to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,5 @@ group :development do
   gem 'pygments.rb', group: [:jekyll_plugins]
   gem 'jekyll-compose', group: [:jekyll_plugins]
   gem 'kramdown', group: [:jekyll_plugins]
+  gem 'json', '~> 2'
 end


### PR DESCRIPTION
This pull adds the json gem dependency to the Gemfile as Jekyll version `3.1.3` does not automatically get the `json` dependency. See [jekyll issue-4838](github.com/jekyll/jekyll/issues/4838) for more details. Below are steps to reproduce and expected error output.

On a fresh install of CentOS 7, I was unable to successfully issue `bundle exec jekyll build` after cloning master. I received the following error:

```
Configuration file: /home/brouse/projects_git/end2end/_config.yml
            Source: source
       Destination: _site
 Incremental build: disabled. Enable with --incremental
      Generating...
bundler: failed to load command: jekyll (/home/brouse/.gem/ruby/bin/jekyll)
LoadError: cannot load such file -- json
  /home/brouse/.gem/ruby/gems/jekyll-3.1.1/lib/jekyll/filters.rb:2:in `require'
  /home/brouse/.gem/ruby/gems/jekyll-3.1.1/lib/jekyll/filters.rb:2:in `<top (required)>'
  /home/brouse/.gem/ruby/gems/jekyll-3.1.1/lib/jekyll/renderer.rb:53:in `run'
  /home/brouse/.gem/ruby/gems/jekyll-3.1.1/lib/jekyll/site.rb:171:in `block (2 levels) in render'
  /home/brouse/.gem/ruby/gems/jekyll-3.1.1/lib/jekyll/site.rb:169:in `each'
  /home/brouse/.gem/ruby/gems/jekyll-3.1.1/lib/jekyll/site.rb:169:in `block in render'
  /home/brouse/.gem/ruby/gems/jekyll-3.1.1/lib/jekyll/site.rb:168:in `each'
  /home/brouse/.gem/ruby/gems/jekyll-3.1.1/lib/jekyll/site.rb:168:in `render'
  /home/brouse/.gem/ruby/gems/jekyll-3.1.1/lib/jekyll/site.rb:59:in `process'
  /home/brouse/.gem/ruby/gems/jekyll-3.1.1/lib/jekyll/command.rb:26:in `process_site'
  /home/brouse/.gem/ruby/gems/jekyll-3.1.1/lib/jekyll/commands/build.rb:60:in `build'
  /home/brouse/.gem/ruby/gems/jekyll-3.1.1/lib/jekyll/commands/build.rb:33:in `process'
  /home/brouse/.gem/ruby/gems/jekyll-3.1.1/lib/jekyll/commands/build.rb:16:in `block (2 levels) in init_with_program'
  /home/brouse/.gem/ruby/gems/mercenary-0.3.5/lib/mercenary/command.rb:220:in `call'
  /home/brouse/.gem/ruby/gems/mercenary-0.3.5/lib/mercenary/command.rb:220:in `block in execute'
  /home/brouse/.gem/ruby/gems/mercenary-0.3.5/lib/mercenary/command.rb:220:in `each'
  /home/brouse/.gem/ruby/gems/mercenary-0.3.5/lib/mercenary/command.rb:220:in `execute'
  /home/brouse/.gem/ruby/gems/mercenary-0.3.5/lib/mercenary/program.rb:42:in `go'
  /home/brouse/.gem/ruby/gems/mercenary-0.3.5/lib/mercenary.rb:19:in `program'
  /home/brouse/.gem/ruby/gems/jekyll-3.1.1/bin/jekyll:13:in `<top (required)>'
  /home/brouse/.gem/ruby/bin/jekyll:23:in `load'
  /home/brouse/.gem/ruby/bin/jekyll:23:in `<top (required)>'
```
