### PR TITLE
Fixed Issue #25

### DIFF
--- a/source/_scss/_layout.scss
+++ b/source/_scss/_layout.scss
@@ -12,6 +12,7 @@ body {
 body {
   border-top: 5px solid $primary-color;
   background: $base-background-color url("../images/bg-pattern.png");
+  word-wrap: break-word; // Fixes Issue #25
 }
 
 .container {


### PR DESCRIPTION
Fixed Issue #25 Long Strings or URLs break CSS Layout
break-word  Allows unbreakable words to be broken

After Fix:
![url_fix_desktop](https://cloud.githubusercontent.com/assets/2684055/17645111/7066f698-6150-11e6-8788-e2add80f5432.jpg)
![url_fix_desktop2](https://cloud.githubusercontent.com/assets/2684055/17645112/7066f1b6-6150-11e6-85c9-a4e9f5b630d8.jpg)
