### PR TITLE
Fixes same comment thread on multiple pages #21 #22

### DIFF
--- a/source/_includes/comments.html
+++ b/source/_includes/comments.html
@@ -7,7 +7,7 @@
     <div id="disqus_thread"></div>
     <script>
       var disqus_config = function() {
-        this.page.url = '{{ site.url }}{{ post.url }}';
+        this.page.url = '{{ site.url }}{{ page.url }}';
         this.page.identifier = '{{ page.id }}';
       };
       (function() {


### PR DESCRIPTION
## Problem:

Same comment thread was being generated across multiple pages.
#21 #22
## Cause of Problem: same disqus_url across all pages:

this.page.url = '{{ site.url }}{{ post.url }}';
site.url worked fine
post.url doesn't return anything

Therefore same disqus_url causes the DISQUS thread ID being same.
## Solution:

Change post.url to page.url which returns the page url and assigns unique Thread ID to each comment thread
