### PR TITLE
fixed main.sass

### DIFF
--- a/source/_sass/main.sass
+++ b/source/_sass/main.sass
@@ -6,7 +6,7 @@
 
 $output-bourbon-deprecation-warnings: false
 
-@import "bourbon";
+@import "bourbon"
 
 @import "variables"
 @import "placeholders"


### PR DESCRIPTION
removed an unneeded ";" from an expected end of line. The theme should now build cleanly.