### PR TITLE
removes Deprecation warning from Jekyll

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 permalink: /blog/:year/:title/
 markdown: kramdown
 highlighter: pygments
-gems: [jekyll-paginate]
+plugins: [jekyll-paginate]
 
 paginate: 3
 paginate_path: "/blog/page/:num/"


### PR DESCRIPTION
There usually pops out a Jekyll Deprecation warning when running bundle exec jekyll ...

This updates the "gems" configuration option with the newly used "plugins" configuration option in _config.yml